### PR TITLE
Print a warning on export failure, and flesh out readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ bundle install
 ```
 
 The core `opencensus` gem and the `google-cloud-trace` client library for the
-Stackdriver API, will be installed automatically as dependencies.
+Stackdriver API will be installed automatically as dependencies.
 
 ### Installing the plugin
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,86 @@
 # Ruby Stackdriver Exporter for OpenCensus
 
-This library exports OpenCensus data to Stackdriver.
+This repository contains the source to the `opencensus-stackdriver` gem. This
+library is a plugin for
+[Ruby OpenCensus](https://github.com/census-instrumentation/opencensus-ruby)
+that exports data to [Stackdriver](https://cloud.google.com/stackdriver/).
+
+OpenCensus is a platform- and provider-agnostic framework for distributed
+tracing and stats collection. For more information, see https://opencensus.io.
+
+This library is in an alpha stage, and the API is subject to change.
+
+## Quick Start
+
+### Installation
+
+Install the gem using Bundler:
+
+1. Add the `opencensus-stackdriver` gem to your application's Gemfile:
+
+```ruby
+gem "opencensus-stackdriver"
+```
+
+2. Use Bundler to install the gem:
+
+```sh
+$ bundle install
+```
+
+The core `opencensus` gem and the `google-cloud-trace` client library for the
+Stackdriver API, will be installed automatically as dependencies.
+
+### Installing the plugin
+
+The Stackdriver plugin can be installed using OpenCensus configuration.
+Insert the following code in your application's initialization:
+
+```ruby
+OpenCensus.configure do |c|
+  c.trace.exporter = OpenCensus::Trace::Exporters::Stackdriver.new
+end
+```
+
+If you are using **Ruby on Rails**, you can equivalently include this code in
+your Rails config:
+
+```ruby
+config.opencensus.trace.exporter = OpenCensus::Trace::Exporters::Stackdriver.new
+```
+
+See the documentation for
+[OpenCensus::Trace::Exporters::Stackdriver](http://www.rubydoc.info/gems/opencensus-stackdriver/OpenCensus/Trace/Exporters/Stackdriver)
+for information on the configuration options for the Stackdriver exporter.
+
+You can find more general information on using OpenCensus from Ruby, including
+configuring automatic trace capture and adding custom spans, in the
+[core `opencensus` README](https://github.com/census-instrumentation/opencensus-ruby).
+
+### Connecting to Stackdriver
+
+If you do not have a Google Cloud project, create one from the
+[cloud console](https://console.cloud.google.com/).
+
+The Stackdriver plugin needs credentials for your project in order to export
+traces to the Stackdriver backend. If your application is running in Google
+Cloud Platform hosting (i.e.
+[Google App Engine](https://cloud.google.com/appengine/),
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/), or
+[Google Compute Engine](https://cloud.google.com/compute/)), then the plugin
+can generally retrieve the needed credentials automatically from the runtime
+environment. See
+[this section](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-trace#running-on-google-cloud-platform)
+from the `google-cloud-trace` README for details.
+
+If you are running the application locally, in self-hosted VMs, or a third
+party hosting service, you will need to provide the project ID and credentials
+(keyfile) to the Google Cloud client library. See
+[this section](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-trace#running-locally-and-elsewhere)
+for details.
+
+Either way, once you have the Stackdriver exporter configured, you can view
+traces on the [Google Cloud Console](https://console.cloud.google.com/traces).
 
 ## About the library
 

--- a/lib/opencensus/stackdriver/version.rb
+++ b/lib/opencensus/stackdriver/version.rb
@@ -15,6 +15,6 @@
 module OpenCensus
   module Stackdriver
     ## Current OpenCensus Stackdriver plugin version
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.0.pre1".freeze
   end
 end

--- a/lib/opencensus/trace/exporters/stackdriver.rb
+++ b/lib/opencensus/trace/exporters/stackdriver.rb
@@ -109,10 +109,14 @@ module OpenCensus
           raise "Exporter is no longer running" unless @executor.running?
 
           @client_promise.execute
-          @client_promise.then do |client|
+          export_promise = @client_promise.then do |client|
             export_as_batch(client, spans)
           end
-          self
+          export_promise.on_error do |reason|
+            warn "Unable to export to Stackdriver because: #{reason}"
+          end
+
+          true
         end
 
         ##


### PR DESCRIPTION
Some cleanup in preparation for release
* Add a quickstart section to the readme
* Print a warning (rather than just failing silently) if an export fails for some reason (e.g. bad or incomplete credentials or project configuration)
