### PR TITLE
Check if the span list is empty before exporting

### DIFF
--- a/lib/opencensus/trace/exporters/stackdriver.rb
+++ b/lib/opencensus/trace/exporters/stackdriver.rb
@@ -108,6 +108,10 @@ module OpenCensus
         def export spans
           raise "Exporter is no longer running" unless @executor.running?
 
+          if spans.nil? || spans.empty?
+            return nil
+          end
+
           @client_promise.execute
           export_promise = @client_promise.then do |client|
             export_as_batch(client, spans)

--- a/lib/opencensus/trace/exporters/stackdriver.rb
+++ b/lib/opencensus/trace/exporters/stackdriver.rb
@@ -108,9 +108,7 @@ module OpenCensus
         def export spans
           raise "Exporter is no longer running" unless @executor.running?
 
-          if spans.nil? || spans.empty?
-            return nil
-          end
+          return nil if spans.nil? || spans.empty?
 
           @client_promise.execute
           export_promise = @client_promise.then do |client|

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -70,9 +70,8 @@ describe OpenCensus::Trace::Exporters::Stackdriver do
       mock_client: mock_client
 
     # Since mock_client doesn't expect the batch_write_spans method to be called, it should raise the NoMethodError if this happens
-    assert_nothing_raised NoMethodError do
-      exporter.export []
-    end
+    exporter.export []
+
     exporter.shutdown
     exporter.wait_for_termination(2)
 

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -69,7 +69,8 @@ describe OpenCensus::Trace::Exporters::Stackdriver do
       project_id: project_id,
       mock_client: mock_client
 
-    # Since mock_client doesn't expect the batch_write_spans method to be called, it should raise the NoMethodError if this happens
+    # Since mock_client doesn't expect the batch_write_spans method to be 
+    # called, it should raise the NoMethodError if this happens
     exporter.export []
 
     exporter.shutdown


### PR DESCRIPTION
This check should prevent the issue described in https://github.com/census-instrumentation/ruby-stackdriver-exporter/issues/8