### PR TITLE
Release version 0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,4 @@
 /spec/reports/
 /tmp/
 
-/docs/_site
-/docs/Gemfile.lock
-/docs/api/
+/docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 before_install: gem install bundler -v 1.16.1
 script:
   - bundle exec rake

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenCensus Stackdriver Exporter
+--markup markdown
+./lib/**/*.rb
+-
+README.md
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.1.1 / 2018-04-13
+
+* Clean unneeded files from the gem
+* Do not issue a write request for an empty span list (bogdanap)
+
 ### 0.1.0 / 2018-03-09
 
 Initial release of the stackdriver export library

--- a/lib/opencensus/stackdriver/version.rb
+++ b/lib/opencensus/stackdriver/version.rb
@@ -15,6 +15,6 @@
 module OpenCensus
   module Stackdriver
     ## Current OpenCensus Stackdriver plugin version
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.1".freeze
   end
 end

--- a/opencensus-stackdriver.gemspec
+++ b/opencensus-stackdriver.gemspec
@@ -13,18 +13,15 @@ Gem::Specification.new do |spec|
   spec.homepage =    "https://github.com/census-instrumentation/ruby-stackdriver-exporter"
   spec.license =     "Apache-2.0"
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = ::Dir.glob("lib/**/*.rb") +
+               ::Dir.glob("*.md") +
+               ["AUTHORS", "LICENSE", ".yardopts"]
   spec.require_paths = ["lib"]
-
   spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_dependency "google-cloud-trace", "~> 0.30"
-  spec.add_dependency "opencensus", "~> 0.2"
+  spec.add_dependency "google-cloud-trace", "~> 0.31"
+  spec.add_dependency "opencensus", "~> 0.3"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "faraday", "~> 0.13"


### PR DESCRIPTION
* Updated travis config to test against latest ruby patches
* Provide yardopts config so rubydoc.info builds docs correctly.
* Update gemspec to whitelist included files—cleans out a bunch of unneeded files.
* Update changelog
