### PR TITLE
Fix rubocop warnings

### DIFF
--- a/lib/opencensus/trace/exporters/stackdriver/converter.rb
+++ b/lib/opencensus/trace/exporters/stackdriver/converter.rb
@@ -347,6 +347,7 @@ module OpenCensus
           #
           def convert_optional_status status
             return nil if status.nil?
+
             Google::Rpc::Status.new code: status.code, message: status.message
           end
 
@@ -358,6 +359,7 @@ module OpenCensus
           #
           def convert_optional_bool value
             return nil if value.nil?
+
             Google::Protobuf::BoolValue.new value: value
           end
 
@@ -369,6 +371,7 @@ module OpenCensus
           #
           def convert_optional_int32 value
             return nil if value.nil?
+
             Google::Protobuf::Int32Value.new value: value
           end
         end


### PR DESCRIPTION
In rubocop v0.59.0, enable `Layout/EmptyLineAfterGuardClause` cop by default.
https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0560-2018-05-14
So the master branch CI is failing now.

I fixed it.