### PR TITLE
Map OpenCensus attribute names to Cloud Trace equivalents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,40 +12,42 @@ AllCops:
 Documentation:
   Enabled: false
 
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Layout/SpaceAroundOperators:
-  Enabled: false
-Metrics/ClassLength:
+Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EmptyLines:
   Enabled: false
-Style/EmptyElse:
+Layout/SpaceAroundOperators:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 25
+Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
 Metrics/MethodLength:
   Max: 25
 Metrics/ParameterLists:
   Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/ClassVars:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/CaseEquality:
-  Enabled: false
-Style/GuardClause:
-  Enabled: false
+Metrics/PerceivedComplexity:
+  Max: 10
 Naming/FileName:
   Exclude:
     - "lib/opencensus-stackdriver.rb"
+Style/CaseEquality:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/MethodDefParentheses:
+  EnforcedStyle: require_no_parentheses
+Style/NumericLiterals:
+  Enabled: false
+Style/RescueModifier:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/TrivialAccessors:
+  Enabled: false

--- a/lib/opencensus/trace/exporters/stackdriver/converter.rb
+++ b/lib/opencensus/trace/exporters/stackdriver/converter.rb
@@ -53,6 +53,20 @@ module OpenCensus
               "exporter [#{::OpenCensus::Stackdriver::VERSION}]"
 
           ##
+          # @private
+          # Mapping for certain well-known attributes defined in
+          # https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md
+          #
+          ATTRIBUTE_NAME_MAPPING = {
+            "http.host" => "/http/host",
+            "http.method" => "/http/method",
+            "http.path" => "/http/path",
+            "http.route" => "/http/route",
+            "http.user_agent" => "/http/user_agent",
+            "http.status_code" => "/http/status_code"
+          }.freeze
+
+          ##
           # Create a converter
           #
           # @param [String] project_id Google project ID
@@ -171,6 +185,16 @@ module OpenCensus
           end
 
           ##
+          # Map OpenCensus attribute name to Stackdriver Trace name.
+          #
+          # @param [String] name OpenCensus attribute name
+          # @return [String] Corresponding Stackdriver Trace attribute.
+          #
+          def convert_attribute_name name
+            ATTRIBUTE_NAME_MAPPING[name] || name
+          end
+
+          ##
           # Convert an attributes hash
           #
           # @param [Hash] attributes The map of attribute values to convert
@@ -187,7 +211,8 @@ module OpenCensus
               attribute_map[AGENT_KEY] = convert_attribute_value AGENT_VALUE
             end
             attributes.each do |k, v|
-              attribute_map[k] = convert_attribute_value v
+              attribute_map[convert_attribute_name k] =
+                convert_attribute_value v
             end
             TraceProtos::Span::Attributes.new \
               attribute_map: attribute_map,

--- a/opencensus-stackdriver.gemspec
+++ b/opencensus-stackdriver.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-focus", "~> 1.1"
   spec.add_development_dependency "rails", "~> 5.1.4"
   spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rubocop", "~> 0.52"
+  spec.add_development_dependency "rubocop", "~> 0.59.2"
   spec.add_development_dependency "yard", "~> 0.9"
   spec.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/test/converter_test.rb
+++ b/test/converter_test.rb
@@ -107,6 +107,31 @@ describe OpenCensus::Trace::Exporters::Stackdriver::Converter do
       proto.dropped_attributes_count.must_equal 2
     end
 
+    it "converts well-known attribute names" do
+      input_attrs = {
+        "http.host" => OpenCensus::Trace::TruncatableString.new("www.google.com"),
+        "http.method" => OpenCensus::Trace::TruncatableString.new("POST"),
+        "http.path" => OpenCensus::Trace::TruncatableString.new("/hello/world"),
+        "http.route" => OpenCensus::Trace::TruncatableString.new("/hello/:entity"),
+        "http.user_agent" => OpenCensus::Trace::TruncatableString.new("OpenCensus/1.0"),
+        "http.status_code" => 200
+      }
+      proto = converter.convert_attributes input_attrs, 2
+      proto.attribute_map["/http/host"].string_value.value.must_equal "www.google.com"
+      proto.attribute_map["/http/method"].string_value.value.must_equal "POST"
+      proto.attribute_map["/http/path"].string_value.value.must_equal "/hello/world"
+      proto.attribute_map["/http/route"].string_value.value.must_equal "/hello/:entity"
+      proto.attribute_map["/http/user_agent"].string_value.value.must_equal "OpenCensus/1.0"
+      proto.attribute_map["/http/status_code"].int_value.must_equal 200
+      proto.attribute_map["http.host"].must_be_nil
+      proto.attribute_map["http.method"].must_be_nil
+      proto.attribute_map["http.path"].must_be_nil
+      proto.attribute_map["http.route"].must_be_nil
+      proto.attribute_map["http.user_agent"].must_be_nil
+      proto.attribute_map["http.status_code"].must_be_nil
+      proto.dropped_attributes_count.must_equal 2
+    end
+
     it "has include_agent_attribute default to false" do
       input_attrs = {"str" => truncatable_string}
       proto = converter.convert_attributes input_attrs, 2


### PR DESCRIPTION
Convert HTTP-related OpenCensus standard attribute names to their Stackdriver Trace equivalents, according to https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md. This change should be released in conjunction with https://github.com/census-instrumentation/opencensus-ruby/pull/85.

Also updated Rubocop and its configs to ensure the build remains green.