### PR TITLE
Support arbitrary resource types.

### DIFF
--- a/lib/opencensus/stats/exporters/stackdriver.rb
+++ b/lib/opencensus/stats/exporters/stackdriver.rb
@@ -40,11 +40,11 @@ module OpenCensus
       class Stackdriver
         # Default custom opencensus domain name
         # @return [String]
-        CUSTOM_OPENCENSUS_DOMAIN = "custom.googleapis.com/opencensus"
+        CUSTOM_OPENCENSUS_DOMAIN = "custom.googleapis.com/opencensus".freeze
 
         # Default metric resouce type.
         # @return [String]
-        GLOBAL_RESOURCE_TYPE = "global"
+        GLOBAL_RESOURCE_TYPE = "global".freeze
 
         # The project ID
         # @return [String]
@@ -58,6 +58,10 @@ module OpenCensus
         # Metric resource type
         # @return [String]
         attr_reader :resource_type
+
+        # Metric resource labels
+        # @return [Hash<String,String>]
+        attr_reader :resource_labels
 
         # Create a Stackdriver exporter.
         #
@@ -97,6 +101,8 @@ module OpenCensus
         #   Default value set to {CUSTOM_OPENCENSUS_DOMAIN}
         # @param [String] resource_type Metric resource type.
         #   Default value set to {GLOBAL_RESOURCE_TYPE}
+        # @param [Hash<String,String>] resource_labels Metric resource labels.
+        #   Default value set to { "project_id" => project_id }
         #
         def initialize \
             project_id: nil,
@@ -109,10 +115,14 @@ module OpenCensus
             auto_terminate_time: 10,
             mock_client: nil,
             metric_prefix: nil,
-            resource_type: nil
+            resource_type: nil,
+            resource_labels: nil
           @project_id = final_project_id project_id
           @metric_prefix = metric_prefix || CUSTOM_OPENCENSUS_DOMAIN
           @resource_type = resource_type || GLOBAL_RESOURCE_TYPE
+          @resource_labels = resource_labels || {
+            "project_id" => @project_id
+          }
           @executor = create_executor max_threads, max_queue
 
           if auto_terminate_time
@@ -315,6 +325,7 @@ module OpenCensus
             @converter.convert_time_series(
               metric_prefix,
               resource_type,
+              resource_labels,
               view_data
             )
           end

--- a/lib/opencensus/stats/exporters/stackdriver/converter.rb
+++ b/lib/opencensus/stats/exporters/stackdriver/converter.rb
@@ -112,10 +112,12 @@ module OpenCensus
           #
           # @param [String] metric_prefix Metric prefix name
           # @param [String] resource_type Metric resource type
+          # @param [Hash<String,String>] resource_labels Metric resource labels
           # @param [OpenCensus::Stats::ViewData] view_data Stats view data
           # @return [Array[Google::Monitoring::V3::TimeSeries]]
           #
-          def convert_time_series metric_prefix, resource_type, view_data
+          def convert_time_series metric_prefix, resource_type, resource_labels,
+                                  view_data
             view = view_data.view
 
             view_data.data.map do |tag_values, aggr_data|
@@ -126,9 +128,7 @@ module OpenCensus
                 },
                 resource: {
                   type: resource_type,
-                  labels: {
-                    "project_id" => @project_id
-                  }
+                  labels: resource_labels
                 },
                 metric_kind: convert_metric_kind(view.aggregation),
                 value_type: convert_metric_value_type(view)

--- a/test/stats/converter_test.rb
+++ b/test/stats/converter_test.rb
@@ -309,14 +309,16 @@ describe OpenCensus::Stats::Exporters::Stackdriver::Converter do
 
       metric_prefix = "test-resource"
       resource_type = "test-resource"
-      series_list = converter.convert_time_series metric_prefix, resource_type, view_data
+      resource_labels = { "project_id" => project_id, "foo" => "bar" }
+      series_list = converter.convert_time_series metric_prefix, resource_type,
+                                                  resource_labels, view_data
       series_list.length.must_equal 1
 
       series = series_list.first
       series.metric.type.must_equal  "#{metric_prefix}/#{view.name}"
-      series.metric.labels.must_equal({"column2"=>"test2", "column1"=>"test1"})
+      assert_equal(series.metric.labels, {"column2"=>"test2", "column1"=>"test1"})
       series.resource.type.must_equal resource_type
-      series.resource.labels.must_equal("project_id" => project_id)
+      assert_equal(series.resource.labels, resource_labels)
       series.metric_kind.must_equal :GAUGE
       series.value_type.must_equal :DOUBLE
       series.points.length.must_equal 1

--- a/test/stats/exporter_test.rb
+++ b/test/stats/exporter_test.rb
@@ -27,6 +27,9 @@ describe OpenCensus::Stats::Exporters::Stackdriver do
   let(:resource_type) {
     "test_resource-type"
   }
+  let(:resource_labels) {
+    { "project_id" => project_id, "foo" => "bar" }
+  }
   let(:measure1) {
     OpenCensus::Stats.create_measure_int name: "size_#{SecureRandom.hex(8)}", unit: "kb"
   }
@@ -80,7 +83,8 @@ describe OpenCensus::Stats::Exporters::Stackdriver do
       view_data2.record measurement2
 
       expected_time_series_protos = [view_data1, view_data2].map do |view_data|
-        converter.convert_time_series metric_prefix, resource_type, view_data
+        converter.convert_time_series metric_prefix, resource_type,
+                                      resource_labels, view_data
       end
       expected_time_series_protos.flatten!
       mock_client.expect :create_time_series, nil, ["projects/#{project_id}", expected_time_series_protos]
@@ -89,6 +93,7 @@ describe OpenCensus::Stats::Exporters::Stackdriver do
         project_id: project_id,
         metric_prefix: metric_prefix,
         resource_type: resource_type,
+        resource_labels: resource_labels,
         mock_client: mock_client
       )
 
@@ -109,6 +114,7 @@ describe OpenCensus::Stats::Exporters::Stackdriver do
         project_id: project_id,
         metric_prefix: metric_prefix,
         resource_type: resource_type,
+        resource_labels: resource_labels,
         mock_client: mock_client
       )
 
@@ -134,6 +140,7 @@ describe OpenCensus::Stats::Exporters::Stackdriver do
         project_id: project_id,
         metric_prefix: metric_prefix,
         resource_type: resource_type,
+        resource_labels: resource_labels,
         mock_client: mock_client
       )
 
@@ -163,6 +170,7 @@ describe OpenCensus::Stats::Exporters::Stackdriver do
         project_id: project_id,
         metric_prefix: metric_prefix,
         resource_type: resource_type,
+        resource_labels: resource_labels,
         mock_client: mock_client
       )
 


### PR DESCRIPTION
The stats exporter now accepts resource labels, which is required in order to support any resource type besides the default global.

Also changed hash comparison in tests from must_equal to assert_equals to support unordered comparison and fix an existing failing test with recent versions of Ruby and minitest.