### PR TITLE
Bump google-cloud-monitoring dependency version as required by #25.

### DIFF
--- a/opencensus-stackdriver.gemspec
+++ b/opencensus-stackdriver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "google-cloud-trace", "~> 0.33"
   spec.add_dependency "opencensus", "~> 0.5"
-  spec.add_dependency "google-cloud-monitoring", "~> 0.29.2"
+  spec.add_dependency "google-cloud-monitoring", "~> 0.30.0"
 
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "faraday", "~> 0.13"

--- a/opencensus-stackdriver.gemspec
+++ b/opencensus-stackdriver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "google-cloud-trace", "~> 0.33"
   spec.add_dependency "opencensus", "~> 0.5"
-  spec.add_dependency "google-cloud-monitoring", "~> 0.30.0"
+  spec.add_dependency "google-cloud-monitoring", "~> 0.35"
 
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "faraday", "~> 0.13"

--- a/opencensus-stackdriver.gemspec
+++ b/opencensus-stackdriver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "google-cloud-trace", "~> 0.33"
   spec.add_dependency "opencensus", "~> 0.5"
-  spec.add_dependency "google-cloud-monitoring", "~> 0.35"
+  spec.add_dependency "google-cloud-monitoring", "~> 0.32"
 
   spec.add_development_dependency "bundler", ">= 1.17"
   spec.add_development_dependency "faraday", "~> 0.13"


### PR DESCRIPTION
Fixes the following error after #25:
```
Unable to export to Monitoring service because: unknown keyword: service_address
```