### PR TITLE
Use aggr_data.time for gauge timestamps.

### DIFF
--- a/lib/opencensus/stats/exporters/stackdriver/converter.rb
+++ b/lib/opencensus/stats/exporters/stackdriver/converter.rb
@@ -159,8 +159,8 @@ module OpenCensus
               create_distribution_point start_time, end_time, aggr_data
             when OpenCensus::Stats::AggregationData::LastValue
               create_number_point(
-                start_time,
-                start_time,
+                end_time,
+                end_time,
                 aggr_data.value,
                 measure
               )


### PR DESCRIPTION
Fix points created with LastValue aggregation to use the time from the aggregation data for both start and end time of the created Point.

For Views using LastValue aggregation, the ViewData's `start_time` is never updated, but the Monitoring Point created [uses `start_time` as the timestamp](https://github.com/census-ecosystem/opencensus-ruby-exporter-stackdriver/blob/master/lib/opencensus/stats/exporters/stackdriver/converter.rb#L162-L163), so every new value/AggregationData is sent with the [original `start_time` of the ViewData](https://github.com/census-ecosystem/opencensus-ruby-exporter-stackdriver/blob/master/lib/opencensus/stats/exporters/stackdriver/converter.rb#L138), and thus only the very first created Point is successfully sent. All successive points retry for the same timestamp, and after 24 hours, this results in Monitoring API errors like:

> Field timeSeries[1].points[0].interval.end_time had an invalid value of "2021-10-20T20:11:57.137003-07:00": Data points cannot be written more than 24h in the past.

(see https://github.com/GoogleCloudPlatform/google-fluentd/issues/345)

This change makes it so the time in the last AggregationData is used instead. I tested this locally and saw new points being ingested.